### PR TITLE
Add 10 new web security testing modules and expand menu to 30 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
                     P E N T E S T   A R S E N A L                
 ```
 
-A comprehensive web application security testing toolkit that combines 20 powerful penetration testing features into one tool.
+A comprehensive web application security testing toolkit that combines 30 powerful penetration testing features into one tool.
 
 ## Author
 
@@ -137,6 +137,47 @@ If you find this tool useful, consider supporting the development:
     - Sends burst requests to detect rate limiting
     - Flags response time spikes or 429 responses
 
+
+21. **Subdomain Takeover Checker**
+    - Checks subdomains for common unclaimed-service fingerprints
+    - Highlights takeover indicators for manual validation
+
+22. **Clickjacking Tester**
+    - Audits X-Frame-Options and CSP frame-ancestors
+    - Flags pages that can likely be embedded in iframes
+
+23. **TLS Configuration Scanner**
+    - Negotiates TLS with the target and shows selected protocol/cipher
+    - Displays certificate issuer, subject, and expiration info
+
+24. **GraphQL Introspection Tester**
+    - Probes common GraphQL endpoints
+    - Checks whether schema introspection is exposed
+
+25. **CSRF Token Checker**
+    - Parses forms and identifies missing anti-CSRF tokens
+    - Focuses on risky POST forms
+
+26. **IDOR Pattern Scanner**
+    - Mutates numeric identifiers in query parameters
+    - Flags suspicious access-control behavior changes
+
+27. **API Version Discovery**
+    - Probes common API and documentation version paths
+    - Surfaces accessible endpoints for deeper review
+
+28. **Cache Poisoning Checker**
+    - Sends cache-related poisoning probes via headers
+    - Detects reflection patterns and reports cache headers
+
+29. **CRLF Injection Tester**
+    - Injects CRLF payloads into query parameters
+    - Checks for header injection behavior
+
+30. **XXE Tester**
+    - Sends XML payloads with external entity references
+    - Flags responses that indicate unsafe XML parsing
+
 ## Installation
 
 1. Clone the repository:
@@ -163,7 +204,7 @@ pip install -r requirements.txt
 python pegasus_pentest.py
 ```
 
-2. Select a tool from the menu (1-20)
+2. Select a tool from the menu (1-30)
 3. Follow the prompts to enter target information
 4. Review the results
 

--- a/modules/api_version_discovery.py
+++ b/modules/api_version_discovery.py
@@ -1,0 +1,50 @@
+from typing import List
+from urllib.parse import urlparse
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+COMMON_API_PATHS: List[str] = [
+    "/api",
+    "/api/v1",
+    "/api/v2",
+    "/api/v3",
+    "/v1",
+    "/v2",
+    "/swagger",
+    "/openapi.json",
+    "/docs",
+]
+
+
+def discover_api_versions(url: str) -> None:
+    parsed = urlparse(url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+
+    found = 0
+    for path in COMMON_API_PATHS:
+        endpoint = f"{base}{path}"
+        response = safe_request(endpoint)
+        if not response:
+            continue
+
+        if response.status_code in [200, 301, 302, 401, 403]:
+            print_success(f"Interesting API endpoint found: {endpoint} [{response.status_code}]")
+            found += 1
+
+    if found == 0:
+        print_warning("No common API version paths discovered")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting API version discovery for: {parsed_url}")
+
+    try:
+        discover_api_versions(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nDiscovery interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/cache_poisoning_checker.py
+++ b/modules/cache_poisoning_checker.py
@@ -1,0 +1,36 @@
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+
+def check_cache_behavior(url: str) -> None:
+    headers = {"X-Forwarded-Host": "evil.example", "X-Original-URL": "/poisoned"}
+    response = safe_request(url, headers=headers)
+    if not response:
+        return
+
+    cache_headers = ["Cache-Control", "Age", "X-Cache", "CF-Cache-Status", "Vary"]
+
+    for header in cache_headers:
+        if header in response.headers:
+            print_info(f"{header}: {response.headers[header]}")
+
+    body = response.text.lower()
+    if "evil.example" in body or "/poisoned" in body:
+        print_warning("Potential cache poisoning signal: injected header reflected in response")
+    else:
+        print_success("No obvious reflection from cache-poisoning headers detected")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting cache poisoning checks for: {parsed_url}")
+
+    try:
+        check_cache_behavior(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nScan interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/clickjacking_tester.py
+++ b/modules/clickjacking_tester.py
@@ -1,0 +1,41 @@
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+
+def test_clickjacking(url: str) -> None:
+    response = safe_request(url)
+    if not response:
+        return
+
+    x_frame_options = response.headers.get("X-Frame-Options", "")
+    csp = response.headers.get("Content-Security-Policy", "")
+
+    if x_frame_options:
+        print_success(f"X-Frame-Options is set: {x_frame_options}")
+    else:
+        print_warning("Missing X-Frame-Options header")
+
+    if "frame-ancestors" in csp.lower():
+        print_success("CSP frame-ancestors directive is configured")
+    else:
+        print_warning("CSP frame-ancestors directive is missing")
+
+    if not x_frame_options and "frame-ancestors" not in csp.lower():
+        print_warning("Potential clickjacking risk detected")
+    else:
+        print_info("Clickjacking protections appear present")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting clickjacking test for: {parsed_url}")
+
+    try:
+        test_clickjacking(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nTest interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/crlf_injection_tester.py
+++ b/modules/crlf_injection_tester.py
@@ -1,0 +1,49 @@
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+PAYLOAD = "%0d%0aX-Injected-Header:%20Pegasus"
+
+
+def generate_test_urls(url: str):
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+
+    for key in params.keys():
+        mutated = params.copy()
+        mutated[key] = [PAYLOAD]
+        query = urlencode(mutated, doseq=True)
+        yield key, urlunparse(parsed._replace(query=query))
+
+
+def test_crlf(url: str) -> None:
+    tested = 0
+    for key, test_url in generate_test_urls(url):
+        tested += 1
+        print_info(f"Testing CRLF payload on parameter '{key}'")
+        response = safe_request(test_url)
+        if not response:
+            continue
+
+        if "X-Injected-Header" in response.headers:
+            print_warning(f"Potential CRLF injection via '{key}'")
+        else:
+            print_success(f"No CRLF header injection detected via '{key}'")
+
+    if tested == 0:
+        print_warning("No query parameters found for CRLF testing")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL with query parameters")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting CRLF injection tests for: {parsed_url}")
+
+    try:
+        test_crlf(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nTest interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/csrf_token_checker.py
+++ b/modules/csrf_token_checker.py
@@ -1,0 +1,51 @@
+from bs4 import BeautifulSoup
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+TOKEN_KEYWORDS = ["csrf", "token", "_token", "authenticity_token", "xsrf"]
+
+
+def check_csrf_tokens(url: str) -> None:
+    response = safe_request(url)
+    if not response:
+        return
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    forms = soup.find_all("form")
+
+    if not forms:
+        print_warning("No forms found on page")
+        return
+
+    print_info(f"Found {len(forms)} forms to analyze")
+
+    for index, form in enumerate(forms, start=1):
+        method = (form.get("method") or "get").lower()
+        inputs = form.find_all("input")
+
+        token_found = any(
+            any(keyword in (inp.get("name") or "").lower() for keyword in TOKEN_KEYWORDS)
+            for inp in inputs
+        )
+
+        if method == "post" and not token_found:
+            print_warning(f"Form #{index} (POST) has no obvious CSRF token")
+        elif method == "post" and token_found:
+            print_success(f"Form #{index} (POST) includes a likely CSRF token")
+        else:
+            print_info(f"Form #{index} uses {method.upper()} method")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting CSRF token check for: {parsed_url}")
+
+    try:
+        check_csrf_tokens(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nCheck interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/graphql_introspection_tester.py
+++ b/modules/graphql_introspection_tester.py
@@ -1,0 +1,41 @@
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+INTROSPECTION_QUERY = {
+    "query": "query IntrospectionQuery { __schema { queryType { name } mutationType { name } types { name } } }"
+}
+
+
+def test_graphql_introspection(url: str) -> None:
+    endpoints = [url, f"{url}/graphql", f"{url}/api/graphql"]
+
+    for endpoint in endpoints:
+        print_info(f"Testing GraphQL endpoint: {endpoint}")
+        response = safe_request(endpoint, method="POST", json=INTROSPECTION_QUERY)
+        if not response:
+            continue
+
+        if response.status_code in [200, 400] and "__schema" in response.text:
+            print_warning(f"GraphQL introspection appears enabled: {endpoint}")
+            return
+        if response.status_code == 404:
+            print_info("Endpoint not found")
+        else:
+            print_success(f"Introspection not exposed on {endpoint} (status {response.status_code})")
+
+    print_warning("No GraphQL endpoint with introspection response was found")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting GraphQL introspection test for: {parsed_url}")
+
+    try:
+        test_graphql_introspection(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nTest interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/idor_pattern_scanner.py
+++ b/modules/idor_pattern_scanner.py
@@ -1,0 +1,56 @@
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+
+def mutate_numeric_params(url: str):
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+
+    for key, values in params.items():
+        value = values[0] if values else ""
+        if value.isdigit():
+            new_value = str(max(0, int(value) + 1))
+            mutated = params.copy()
+            mutated[key] = [new_value]
+            new_query = urlencode(mutated, doseq=True)
+            yield key, urlunparse(parsed._replace(query=new_query))
+
+
+def test_idor_patterns(url: str) -> None:
+    baseline = safe_request(url)
+    if not baseline:
+        return
+
+    tested = 0
+    for key, mutated_url in mutate_numeric_params(url):
+        tested += 1
+        print_info(f"Testing parameter '{key}' with modified ID: {mutated_url}")
+        response = safe_request(mutated_url)
+        if not response:
+            continue
+
+        if response.status_code == 200 and len(response.text) != len(baseline.text):
+            print_warning(f"Potential IDOR pattern on parameter '{key}'")
+        elif response.status_code in [401, 403]:
+            print_success(f"Access control enforced for parameter '{key}'")
+        else:
+            print_info(f"Response status for '{key}': {response.status_code}")
+
+    if tested == 0:
+        print_warning("No numeric query parameters found for IDOR-style mutation")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL with query parameters")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting IDOR pattern scan for: {parsed_url}")
+
+    try:
+        test_idor_patterns(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nScan interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/subdomain_takeover_checker.py
+++ b/modules/subdomain_takeover_checker.py
@@ -1,0 +1,50 @@
+from typing import Dict
+from utils.common import print_info, print_success, print_error, print_warning, safe_request
+
+
+FINGERPRINTS: Dict[str, str] = {
+    "there isn't a github pages site here": "Possible GitHub Pages takeover",
+    "no such app": "Possible Heroku takeover",
+    "the specified bucket does not exist": "Possible AWS S3 bucket takeover",
+    "no such bucket": "Possible cloud bucket takeover",
+    "project not found": "Possible Vercel/Render project takeover",
+}
+
+
+def check_takeover(subdomain: str) -> None:
+    for scheme in ["https://", "http://"]:
+        url = f"{scheme}{subdomain}"
+        print_info(f"Testing {url}")
+        response = safe_request(url)
+        if not response:
+            continue
+
+        body = response.text.lower()
+        matched = False
+        for fingerprint, finding in FINGERPRINTS.items():
+            if fingerprint in body:
+                print_warning(f"{finding} detected on {url}")
+                matched = True
+
+        if response.status_code in [404, 410] and not matched:
+            print_info(f"{url} returned {response.status_code} but no known fingerprint")
+        elif not matched:
+            print_success(f"No obvious takeover fingerprint found on {url}")
+        return
+
+    print_error("Failed to reach target with both HTTP and HTTPS")
+
+
+def start_scan(subdomain: str) -> None:
+    if not subdomain:
+        print_error("Please provide a valid subdomain")
+        return
+
+    print_info(f"Starting subdomain takeover check for: {subdomain}")
+
+    try:
+        check_takeover(subdomain.strip())
+    except KeyboardInterrupt:
+        print_warning("\nScan interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/modules/tls_configuration_scanner.py
+++ b/modules/tls_configuration_scanner.py
@@ -1,0 +1,56 @@
+import ssl
+import socket
+from urllib.parse import urlparse
+from utils.common import print_info, print_success, print_error, print_warning, parse_url
+
+
+def scan_tls(url: str) -> None:
+    parsed = urlparse(parse_url(url))
+    host = parsed.hostname
+    port = parsed.port or 443
+
+    if not host:
+        print_error("Could not parse host from URL")
+        return
+
+    context = ssl.create_default_context()
+    with socket.create_connection((host, port), timeout=10) as sock:
+        with context.wrap_socket(sock, server_hostname=host) as tls_sock:
+            cert = tls_sock.getpeercert()
+            cipher = tls_sock.cipher()
+            version = tls_sock.version()
+
+            print_success(f"TLS version negotiated: {version}")
+            if cipher:
+                print_info(f"Cipher suite: {cipher[0]} ({cipher[1]})")
+
+            subject = cert.get("subject", [])
+            issuer = cert.get("issuer", [])
+            not_after = cert.get("notAfter", "Unknown")
+
+            print_info(f"Certificate expires on: {not_after}")
+            if subject:
+                print_info(f"Certificate subject: {subject[0]}")
+            if issuer:
+                print_info(f"Certificate issuer: {issuer[0]}")
+
+            weak_versions = {"TLSv1", "TLSv1.1", "SSLv3", "SSLv2"}
+            if version in weak_versions:
+                print_warning(f"Weak TLS version in use: {version}")
+            else:
+                print_success("TLS protocol version appears modern")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid URL")
+        return
+
+    print_info(f"Starting TLS configuration scan for: {url}")
+
+    try:
+        scan_tls(url)
+    except KeyboardInterrupt:
+        print_warning("\nScan interrupted by user")
+    except Exception as exc:
+        print_error(f"TLS scan failed: {str(exc)}")

--- a/modules/xxe_tester.py
+++ b/modules/xxe_tester.py
@@ -1,0 +1,36 @@
+from utils.common import print_info, print_success, print_error, print_warning, parse_url, safe_request
+
+XXE_PAYLOAD = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE foo [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>
+<root><item>&xxe;</item></root>"""
+
+
+def test_xxe(url: str) -> None:
+    headers = {"Content-Type": "application/xml"}
+    response = safe_request(url, method="POST", data=XXE_PAYLOAD, headers=headers)
+    if not response:
+        return
+
+    body = response.text.lower()
+    if "root:x:" in body or "/bin/bash" in body:
+        print_warning("Potential XXE behavior detected in response")
+    elif response.status_code in [400, 415]:
+        print_success("Server appears to reject XML/XXE payloads")
+    else:
+        print_info(f"Received status {response.status_code}; manual verification recommended")
+
+
+def start_scan(url: str) -> None:
+    if not url:
+        print_error("Please provide a valid XML-capable endpoint URL")
+        return
+
+    parsed_url = parse_url(url)
+    print_info(f"Starting XXE test for: {parsed_url}")
+
+    try:
+        test_xxe(parsed_url)
+    except KeyboardInterrupt:
+        print_warning("\nTest interrupted by user")
+    except Exception as exc:
+        print_error(f"An error occurred: {str(exc)}")

--- a/pegasus_pentest.py
+++ b/pegasus_pentest.py
@@ -27,6 +27,16 @@ from modules.host_header_injection import start_scan as start_host_header_scan
 from modules.http_method_tester import start_scan as start_method_scan
 from modules.cookie_security_checker import start_scan as start_cookie_scan
 from modules.rate_limit_tester import start_scan as start_rate_limit_scan
+from modules.subdomain_takeover_checker import start_scan as start_subdomain_takeover_scan
+from modules.clickjacking_tester import start_scan as start_clickjacking_scan
+from modules.tls_configuration_scanner import start_scan as start_tls_scan
+from modules.graphql_introspection_tester import start_scan as start_graphql_scan
+from modules.csrf_token_checker import start_scan as start_csrf_scan
+from modules.idor_pattern_scanner import start_scan as start_idor_scan
+from modules.api_version_discovery import start_scan as start_api_discovery_scan
+from modules.cache_poisoning_checker import start_scan as start_cache_poisoning_scan
+from modules.crlf_injection_tester import start_scan as start_crlf_scan
+from modules.xxe_tester import start_scan as start_xxe_scan
 
 def show_menu() -> None:
     """Display the main menu"""
@@ -51,17 +61,27 @@ def show_menu() -> None:
     print("18. HTTP Method Tester")
     print("19. Cookie Security Checker")
     print("20. Rate Limiting Tester")
+    print("21. Subdomain Takeover Checker")
+    print("22. Clickjacking Tester")
+    print("23. TLS Configuration Scanner")
+    print("24. GraphQL Introspection Tester")
+    print("25. CSRF Token Checker")
+    print("26. IDOR Pattern Scanner")
+    print("27. API Version Discovery")
+    print("28. Cache Poisoning Checker")
+    print("29. CRLF Injection Tester")
+    print("30. XXE Tester")
     print("0. Exit")
 
 def get_user_choice() -> int:
     """Get user's menu choice"""
     while True:
         try:
-            choice = input("\nEnter your choice (0-20): ")
+            choice = input("\nEnter your choice (0-30): ")
             choice = int(choice)
-            if 0 <= choice <= 20:
+            if 0 <= choice <= 30:
                 return choice
-            print_error("Please enter a number between 0 and 20")
+            print_error("Please enter a number between 0 and 30")
         except ValueError:
             print_error("Please enter a valid number")
 
@@ -167,6 +187,46 @@ def main() -> None:
             elif choice == 20:
                 url = get_target_input("Enter target URL: ")
                 start_rate_limit_scan(url)
+
+            elif choice == 21:
+                subdomain = get_target_input("Enter target subdomain (e.g., app.example.com): ")
+                start_subdomain_takeover_scan(subdomain)
+
+            elif choice == 22:
+                url = get_target_input("Enter target URL: ")
+                start_clickjacking_scan(url)
+
+            elif choice == 23:
+                url = get_target_input("Enter target URL: ")
+                start_tls_scan(url)
+
+            elif choice == 24:
+                url = get_target_input("Enter target URL: ")
+                start_graphql_scan(url)
+
+            elif choice == 25:
+                url = get_target_input("Enter target URL: ")
+                start_csrf_scan(url)
+
+            elif choice == 26:
+                url = get_target_input("Enter target URL with numeric parameters: ")
+                start_idor_scan(url)
+
+            elif choice == 27:
+                url = get_target_input("Enter target URL: ")
+                start_api_discovery_scan(url)
+
+            elif choice == 28:
+                url = get_target_input("Enter target URL: ")
+                start_cache_poisoning_scan(url)
+
+            elif choice == 29:
+                url = get_target_input("Enter target URL with parameters: ")
+                start_crlf_scan(url)
+
+            elif choice == 30:
+                url = get_target_input("Enter XML endpoint URL: ")
+                start_xxe_scan(url)
             
             input("\nPress Enter to continue...")
             


### PR DESCRIPTION
### Motivation
- Expand the toolkit coverage by adding common web security probes that help surface takeover, header, TLS, XML, API, and caching weaknesses.
- Provide users a single menu-driven interface to run a broader set of quick checks for reconnaissance and basic vulnerability signals.

### Description
- Added 10 new modules under `modules/`: `subdomain_takeover_checker.py`, `clickjacking_tester.py`, `tls_configuration_scanner.py`, `graphql_introspection_tester.py`, `csrf_token_checker.py`, `idor_pattern_scanner.py`, `api_version_discovery.py`, `cache_poisoning_checker.py`, `crlf_injection_tester.py`, and `xxe_tester.py` implementing lightweight checks and `start_scan` entrypoints.
- Wired new modules into the main launcher by importing them in `pegasus_pentest.py`, extending the menu to options `21–30`, and updating input validation to accept choices `0-30` and corresponding handlers that call each module's `start_scan` function.
- Updated `README.md` to document the expanded feature list and changed usage instructions to reflect `1-30` options.
- Performed a source-level sanity pass by compiling Python files to catch syntax issues using a simple compile check.

### Testing
- Ran `python -m py_compile pegasus_pentest.py modules/*.py utils/*.py` which completed successfully with no syntax errors reported.
- No additional automated unit tests were present or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d41b5332648329be0ffb6dec86ef9f)